### PR TITLE
remove attributes from tags_context

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,7 @@ locals {
     stage       = local.stage
     # For AWS we need `Name` to be disambiguated since it has a special meaning
     name       = local.id
-    attributes = local.id_context.attributes
+    # attributes = local.id_context.attributes
   }
 
   generated_tags = {


### PR DESCRIPTION
## what

- Remove attributes from tags_context

## why
To match the current state of the infrastructure

## references


